### PR TITLE
Bugfix: The order of the tag is by name and not date

### DIFF
--- a/modules/metalsmith.js
+++ b/modules/metalsmith.js
@@ -258,7 +258,9 @@ module.exports = function(lang, isStaging) {
           })
           .use(tags({
             handle: 'tags',
-            path: 'tags/:tag.html'
+            path: 'tags/:tag.html',
+            sortBy: 'date',
+            reverse: true
           }))
           .use(wordcloud({
             category: 'tags',


### PR DESCRIPTION
I have noticed that the order of the tags, is by name and not by date. For example https://onsen.io/blog/tags/monaca.html displays the first post for january 8th also the newest post is from january 16th.  This is confusing, because it is inconsistent with the rest of the page. This should fix the bug. I have attached a before and after html file.

[bugfix-pages.zip](https://github.com/OnsenUI/onsen.io/files/97184/bugfix-pages.zip)
