### PR TITLE
Fixed blog header.

### DIFF
--- a/src/less/_blog_header.less
+++ b/src/less/_blog_header.less
@@ -392,6 +392,8 @@
 
 .blog-header + .blog-header {
   .tablet-query({
-    display: none;
+    .blog-header-inner {
+      display: none;
+    }
   });
 }


### PR DESCRIPTION
@argelius the blog header was bugged when the tablet media query was triggered. It was hiding all the content (like blog posts) instead of just the categories. This fixes it.

I'll merge as it's quite important, let me know if there is any problem. 