### PR TITLE
Show `translation in progress` message when translated contents are unavailable.

### DIFF
--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -287,9 +287,11 @@ module.exports = function() {
         return file.doc.elements.filter(function(v) { return v.extensionOf == framework })[0];
       },
 
-      translate: function(message) {
+      translate: function(message, lang) {
 
-        var lang = this.lang;
+        if (!lang){
+          lang = this.lang;
+        }
 
         if (typeof message !== 'string') {
           return message;

--- a/src/misc/item-reference.html
+++ b/src/misc/item-reference.html
@@ -179,7 +179,18 @@ actionbar: false
               <% end %>
             </td>
             <td>
+              <% if @lang == "en": %>
               <%- @markd @translate attribute.description %>
+              <% else: %>
+              <% if @translate(attribute.description).length != 0: %>
+              <%- @markd @translate attribute.description %>
+              <% else: %>
+              <span style="opacity: 0.6;">
+                <%- @markd @translate(attribute.description, "en") %>
+                <span style="color: red;">（翻訳中）</span>
+              </span>
+              <% end %>
+              <% end %>
 
               <% if attribute.required: %>
               <span style="font-size: 12px;"><% if @lang == "en": %>Required.<% else: %>必須<% end %></span>
@@ -228,7 +239,19 @@ actionbar: false
           <td class="attribute-name">
             <%= property.name %>
           </td>
-          <td><%- @markd @translate property.description %>
+          <td>
+            <% if @lang == "en": %>
+            <%- @markd @translate property.description %>
+            <% else: %>
+            <% if @translate(property.description).length != 0: %>
+            <%- @markd @translate property.description %>
+            <% else: %>
+            <span style="opacity: 0.6;">
+              <%- @markd @translate(property.description, "en") %>
+              <span style="color: red;">（翻訳中）</span>
+            </span>
+            <% end %>
+            <% end %>
             <% if property.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
           </td>
         </tr>
@@ -277,7 +300,18 @@ actionbar: false
               <% end %>
             </td>
             <td>
+              <% if @lang == "en": %>
               <%- @markd @translate prop.description %>
+              <% else: %>
+              <% if @translate(prop.description).length != 0: %>
+              <%- @markd @translate prop.description %>
+              <% else: %>
+              <span style="opacity: 0.6;">
+                <%- @markd @translate(prop.description, "en") %>
+                <span style="color: red;">（翻訳中）</span>
+              </span>
+              <% end %>
+              <% end %>
 
               <% if prop.required == "true": %>
                 <span style="font-size: 12px;"><% if @lang == "en": %>Required.<% else: %>必須<% end %></span>
@@ -322,7 +356,20 @@ actionbar: false
         <% for modifier in @doc.modifiers: %>
         <tr>
           <td class="modifier-name" id="<%= @doc.name %>-<%= modifier.name %>"><%= modifier.name %></td>
-          <td><%- @markd @translate modifier.description %></td>
+          <td>
+            <% if @lang == "en": %>
+            <%- @markd @translate modifier.description %>
+            <% else: %>
+            <% if @translate(modifier.description).length != 0: %>
+            <%- @markd @translate modifier.description %>
+            <% else: %>
+            <span style="opacity: 0.6;">
+              <%- @markd @translate(modifier.description, "en") %>
+              <span style="color: red;">（翻訳中）</span>
+            </span>
+            <% end %>
+            <% end %>
+          </td>
         </tr>
         <% end %>
       </tbody>
@@ -356,7 +403,19 @@ actionbar: false
             <td>
               <a href="#method-<%= method.name %>"><%= method.signature || method.name %> </a>
             </td>
-            <td><%- @markd @translate method.description %>
+            <td>
+              <% if @lang == "en": %>
+              <%- @markd @translate method.description %>
+              <% else: %>
+              <% if @translate(method.description).length != 0: %>
+              <%- @markd @translate method.description %>
+              <% else: %>
+              <span style="opacity: 0.6;">
+                <%- @markd @translate(method.description, "en") %>
+                <span style="color: red;">（翻訳中）</span>
+              </span>
+              <% end %>
+              <% end %>
               <% if method.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
             </td>
           </tr>
@@ -390,7 +449,19 @@ actionbar: false
         <% for event in @ownedEvents: %>
           <tr>
             <td><a href="#event-<%= event.name %>"><%= event.name %></a></td>
-            <td><%- @markd @translate event.description %>
+            <td>
+              <% if @lang == "en": %>
+              <%- @markd @translate event.description %>
+              <% else: %>
+              <% if @translate(event.description).length != 0: %>
+              <%- @markd @translate event.description %>
+              <% else: %>
+              <span style="opacity: 0.6;">
+                <%- @markd @translate(event.description, "en") %>
+                <span style="color: red;">（翻訳中）</span>
+              </span>
+              <% end %>
+              <% end %>
               <% if event.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
             </td>
           </tr>
@@ -414,7 +485,20 @@ actionbar: false
           <a href="#method-<%= method.name %>" class="reference-loop-anchor"></a>
         </h4>
 
-        <p><%- @markd @translate method.description %></p>
+        <p>
+          <% if @lang == "en": %>
+          <%- @markd @translate method.description %>
+          <% else: %>
+          <% if @translate(method.description).length != 0: %>
+          <%- @markd @translate method.description %>
+          <% else: %>
+          <span style="opacity: 0.6;">
+            <%- @markd @translate(method.description, "en") %>
+            <span style="color: red;">（翻訳中）</span>
+          </span>
+          <% end %>
+          <% end %>
+        </p>
 
         <% if method.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
 
@@ -445,7 +529,20 @@ actionbar: false
             <tr>
               <td><span class="parameter-name"><%= param.name %></span></td>
               <td class="value-type"><%= param.type %></td>
-              <td><%- @markd @translate param.description %></td>
+              <td>
+                <% if @lang == "en": %>
+                <%- @markd @translate param.description %>
+                <% else: %>
+                <% if @translate(param.description).length != 0: %>
+                <%- @markd @translate param.description %>
+                <% else: %>
+                <span style="opacity: 0.6;">
+                  <%- @markd @translate(param.description, "en") %>
+                  <span style="color: red;">（翻訳中）</span>
+                </span>
+                <% end %>
+                <% end %>
+              </td>
             </tr>
             <% end %>
           </tbody>
@@ -470,7 +567,20 @@ actionbar: false
           <a href="#event-<%= event.name %>" class="reference-loop-anchor"></a>
         </h4>
 
-        <p><%- @markd @translate event.description %></p>
+        <p>
+          <% if @lang == "en": %>
+          <%- @markd @translate event.description %>
+          <% else: %>
+          <% if @translate(event.description).length != 0: %>
+          <%- @markd @translate event.description %>
+          <% else: %>
+          <span style="opacity: 0.6;">
+            <%- @markd @translate(event.description, "en") %>
+            <span style="color: red;">（翻訳中）</span>
+          </span>
+          <% end %>
+          <% end %>
+        </p>
 
         <% if event.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
 
@@ -495,7 +605,20 @@ actionbar: false
             <tr>
               <td><span class="parameter-name"><%= param.name %></span></td>
               <td class="value-type"><%= param.type %></td>
-              <td><%- @markd @translate param.description %></td>
+              <td>
+                <% if @lang == "en": %>
+                <%- @markd @translate param.description %>
+                <% else: %>
+                <% if @translate(param.description).length != 0: %>
+                <%- @markd @translate param.description %>
+                <% else: %>
+                <span style="opacity: 0.6;">
+                  <%- @markd @translate(param.description, "en") %>
+                  <span style="color: red;">（翻訳中）</span>
+                </span>
+                <% end %>
+                <% end %>
+              </td>
             </tr>
             <% end %>
           </tbody>
@@ -530,7 +653,19 @@ actionbar: false
               <tr>
                 <td><%= input.name %></td>
                 <td><%= input.type %></td>
-                <td><%- @markd @translate input.description %>
+                <td>
+                  <% if @lang == "en": %>
+                  <%- @markd @translate input.description %>
+                  <% else: %>
+                  <% if @translate(input.description).length != 0: %>
+                  <%- @markd @translate input.description %>
+                  <% else: %>
+                  <span style="opacity: 0.6;">
+                    <%- @markd @translate(input.description, "en") %>
+                    <span style="color: red;">（翻訳中）</span>
+                  </span>
+                  <% end %>
+                  <% end %>
                   <% if input.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
                 </td>
               </tr>
@@ -564,7 +699,19 @@ actionbar: false
               <tr>
                 <td><%= output.name %></td>
                 <td><%= output.type %></td>
-                <td><%- @markd @translate output.description %>
+                <td>
+                  <% if @lang == "en": %>
+                  <%- @markd @translate output.description %>
+                  <% else: %>
+                  <% if @translate(output.description).length != 0: %>
+                  <%- @markd @translate output.description %>
+                  <% else: %>
+                  <span style="opacity: 0.6;">
+                    <%- @markd @translate(output.description, "en") %>
+                    <span style="color: red;">（翻訳中）</span>
+                  </span>
+                  <% end %>
+                  <% end %>
                   <% if output.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
                 </td>
               </tr>


### PR DESCRIPTION
@argelius @frankdiox @anatoo 
Requested by @kanakoubukata.

I have made the following changes:
* Add 2nd argument `lang` to `translate` function in `helper.js`.
* Change templates to show English contents and `translation in progress` message when translated contents are unavailable.

Screenshot:
![2016-11-15 19 08 07](https://cloud.githubusercontent.com/assets/19771915/20304939/42111024-ab76-11e6-9673-41c40d5d643c.png)

I think this code is redundant but there might be no good alternatives.
If it is acceptable, could you merge this PR?