### PR TITLE
Add English blog post `monaca-cli-transpile` again.

### DIFF
--- a/blog/authors/atsushi.markdown
+++ b/blog/authors/atsushi.markdown
@@ -2,6 +2,7 @@
 id: atsushi
 name: "Atsushi Nakatsugawa"
 gravatar: 4cafe6a1c6287d64d7252279eeeffa94
+url: http://www.moongift.jp/
 ---
 
 Atsushi is the Chief Editor of Moongift, one of the most popular open source bogs in Japan. He's active within the open-source community as a consultant and developer.

--- a/blog/authors/moongift.markdown
+++ b/blog/authors/moongift.markdown
@@ -1,6 +1,0 @@
----
-id: moongift
-name: "Atsushi Nakatsugawa"
-gravatar: 4cafe6a1c6287d64d7252279eeeffa94
-url: http://www.moongift.jp/
----

--- a/blog/posts/2015-10-19.markdown
+++ b/blog/posts/2015-10-19.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift 
+author: atsushi 
 date: 2015-10-19
 id: create-your-kintone-app-using-monaca
 title: "Create your Kintone app using Monaca"

--- a/blog/posts/2016-01-08.markdown
+++ b/blog/posts/2016-01-08.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-01-08
 id: 6-things-you-can-do-with-monaca-localkit
 title: "6 Things You Can Do with Monaca LocalKit"

--- a/blog/posts/2016-01-13.markdown
+++ b/blog/posts/2016-01-13.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-01-13
 id: test-your-javascript-code-with-these-unit-testing-frameworks
 title: "Test your Javascript Code with these Unit Testing Frameworks"

--- a/blog/posts/2016-01-29.markdown
+++ b/blog/posts/2016-01-29.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-01-29
 id: 3-ways-to-save-important-data-in-monaca-apps
 title: "3 Ways to Save Important Data in Monaca Apps"

--- a/blog/posts/2016-02-16.markdown
+++ b/blog/posts/2016-02-16.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-02-16
 id: create-cross-platform-app-with-electron-and-onsen-ui
 title: "Create Cross-Platform App with Electron and Onsen UI"

--- a/blog/posts/2016-02-22.markdown
+++ b/blog/posts/2016-02-22.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-02-22
 id: trying-out-javascript-es6-using-babel
 title: "Trying out JavaScript ES6 using Babel"

--- a/blog/posts/2016-03-23.markdown
+++ b/blog/posts/2016-03-23.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-03-23
 id: localkit-web-ide-everything-you-need-to-know-about-monaca-development-environment
 title: "LocalKit, Web IDE: Everything You Need to Know about Monaca Development Environment"

--- a/blog/posts/2016-05-11.markdown
+++ b/blog/posts/2016-05-11.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-05-11
 id: creating-monaca-applications-with-es6
 title: "Creating Monaca Applications With ES6"

--- a/blog/posts/2016-08-04.markdown
+++ b/blog/posts/2016-08-04.markdown
@@ -1,5 +1,5 @@
 ---
-author: moongift
+author: atsushi
 date: 2016-08-04
 id: develop-monaca-project-with-visual-studio-code
 title: "Develop a Monaca Project with Visual Studio Code"

--- a/blog/posts/2017-02-03.markdown
+++ b/blog/posts/2017-02-03.markdown
@@ -1,0 +1,105 @@
+---
+author: atsushi
+date: 2017-02-03
+id: monaca-cli-transpile
+title: "Transpile projects with Monaca CLI"
+product: monaca
+tags: monaca, cli
+category: tutorial
+---
+
+Monaca CLI is a command-line tool which makes local development of Monaca apps easier. Recently, a new function called "transpile" has been added to Monaca CLI. It can be used to transpile code for React/Angular 2 apps.
+
+We will explain in details about the `transpile` option.
+
+## Installation of Monaca CLI
+
+To use Monaca CLI, Node.js is required. After installing Node.js, use `npm` (or yarn) in the command prompt to install Monaca as follows:
+
+```
+$ npm install monaca -g
+```
+
+## Usage
+
+Transpilation is used to convert languages like JSX (React) or Typescript (Angular 2) into something that can be executed by the browser.  If you want to create a project with React, select the category 'Onsen UI and React' and then choose the desired template as following:
+
+```
+$ monaca create react_monaca
+? Choose a category:
+  Onsen UI
+  Onsen UI and Angular 1
+  Onsen UI and Angular 2
+❯ Onsen UI and React
+  Ionic
+  No Framework
+  Sample Apps
+```
+
+A directory called `src` has been created. The React app source code has been stored in this directory.
+
+```
+$ tree src/
+src/
+├── App.jsx
+├── HomePage.jsx
+├── SettingsPage.jsx
+├── main.jsx
+└── public
+    └── index.html.ejs
+
+1 directory, 5 files
+```
+
+It is written as JSX as above. This could not be used as Monaca app without transpiling into ES5. Therefore, transpile is applied below.
+
+### How to transpile
+
+Running the following monaca command will transpile the code.
+
+- monaca upload
+- monaca preview
+- monaca debug
+- monaca remote build
+
+Transpilation is performed automatically in Monaca CLI. To execute transpile alone, use the command below. Fonts, JS and stylesheet will be minified.
+
+```
+$ monaca transpile
+Running Transpiler...
+Build completed in 13.312s
+
+Time: 13314ms
+                                                                    Asset       Size  Chunks             Chunk Names
+                     assets/ionicons.aff28a207631f39ee0272d5cdde43ee7.svg     334 kB          [emitted]  
+          assets/fontawesome-webfont.25a32416abee198dd821b0b17a198a8f.eot    76.5 kB          [emitted]  
+         assets/fontawesome-webfont.c8ddf1e5e5bf3682bc7bebf30f394148.woff    90.4 kB          [emitted]  
+          assets/fontawesome-webfont.1dc35d25e61d819a9c357074014867ab.ttf     153 kB          [emitted]  
+          assets/fontawesome-webfont.d7c639084f684d66a1bc66855d193ed8.svg     392 kB          [emitted]  
+                     assets/ionicons.19e65b89cee273a249fba4c09b951b74.eot     121 kB          [emitted]  
+                     assets/ionicons.dd4781d1acc57ba4c4808d1b44301201.ttf     189 kB          [emitted]  
+                    assets/ionicons.2c159d0d05473040b53ec79df8797d32.woff    67.9 kB          [emitted]  
+        assets/fontawesome-webfont.e6cf7c6ec7c2d6f670ae9d762604cb0b.woff2    71.9 kB          [emitted]  
+assets/Material-Design-Iconic-Font.a4d31128b633bc0b1cc1f18a34fb3851.woff2    38.4 kB          [emitted]  
+ assets/Material-Design-Iconic-Font.d2a55d331bdd1a7ea97a8a1fbb3c569c.woff    50.3 kB          [emitted]  
+  assets/Material-Design-Iconic-Font.b351bd62abcd96e924d9f44a3da169a7.ttf    99.2 kB          [emitted]  
+                                                            app.bundle.js    88.1 kB       0  [emitted]  app
+                                                         vendor.bundle.js     454 kB       1  [emitted]  vendor
+                                                                  app.css     126 kB       0  [emitted]  app
+                                                               index.html  620 bytes          [emitted]  
+
+
+Transpiling finished for /path_to/react_monaca
+```
+
+If the command is successfully executed, these files will be placed in the `www` directory. This means files are being generated to be used as a Monaca app. The only exception is `monaca preview`, which keeps the result in memory (instead of `www` directory) in order to speed up the development process.
+
+Next, all you need to do is to create React or Angular2 App.
+
+![](/blog/content/images/2016/Nov/monaca-react-preview.png)
+
+----
+
+Gulp could also be used to transpile; however, it consumes a lot of time. In this case, we recommend using Monaca to create the hybrid app easily.
+
+[Monaca CLI command - Monaca Docs](https://docs.monaca.io/en/manual/development/monaca_cli/cli_commands/#monaca-transpile)

--- a/config.js
+++ b/config.js
@@ -43,7 +43,7 @@ module.exports = function(language, isStaging) {
       name: 'Monaca Team',
       url: 'https://monaca.io',
     },
-    moongift: {
+    atsushi: {
       name: 'Atsushi Nakatsugawa',
       gravator: '4cafe6a1c6287d64d7252279eeeffa94'
     },
@@ -70,9 +70,6 @@ module.exports = function(language, isStaging) {
     konstantin: {
       name: 'Konstantin Dinev',
       gravator: '31893df4323fac99458ed86784e25a77'
-    },
-    atsushi: {
-      name: '中津川篤司',
     },
     ryoichi: {
       name: 'Ryoichi Tsukada',


### PR DESCRIPTION
@mdeguchi 

@moongift さんによる[日本語記事](https://ja.onsen.io/blog/monaca-cli-transpile/)の英語版用のプルリクを再作成しました。
2017/02/03 に以下の作業をお願いいたします。

- [ ] このプルリクエストをマージする（`blog-en-monaca-cli-transpile` ブランチを `master` ブランチにマージする）
- [ ] 10-20 分ほど待つ
- [ ] ステージング環境（ http://s.onsen.io/blog/ ）で記事が正常に表示されるか確認する
    - **本番環境と違って [https だと](https://s.onsen.io/blog/)サーバからレスポンスが返ってこないので注意!!!**
- [ ] `master` ブランチを `production` ブランチにマージする
- [ ] 1時間ほど待つ
- [ ] 本番環境（ https://onsen.io/blog/ ）で記事が正常に表示されるか確認する