### PR TITLE
Support Open Graph protocol (OGP), Facebook OGP and Twitter Cards for /blog/.

### DIFF
--- a/blog/posts/2017-03-01.markdown
+++ b/blog/posts/2017-03-01.markdown
@@ -6,6 +6,13 @@ title: "Status of Vue 2 binding alpha and roadmap for beta"
 product: onsen
 category: announcement
 tags: vue, onsen ui
+# Open Graph protocol metadata
+og:
+  # Set og:image
+  image: https://onsen.io/blog/content/images/2016/Aug/onsen_vue.png
+  twitter:
+    # Set type of Twitter Card: summary, summary_large_image
+    card: summary_large_image
 ---
 
 ![Onsen UI and Vue.js](https://onsen.io/blog/content/images/2016/Aug/onsen_vue.png)

--- a/blog_ja/posts/2017-03-01.markdown
+++ b/blog_ja/posts/2017-03-01.markdown
@@ -6,6 +6,13 @@ title: "Onsen UI for Vue 2 の開発状況（2017年3月版）"
 product: onsen-ui
 tags: onsen ui, vue
 category: 技術情報
+# Open Graph protocol (OGP) 用の情報を設定
+og:
+  # og:image を設定
+  image: https://onsen.io/blog/content/images/2016/Aug/onsen_vue.png
+  twitter:
+    # Twitter Card の種類を設定: summary, summary_large_image
+    card: summary_large_image
 ---
 
 ![Onsen UI and Vue.js](https://onsen.io/blog/content/images/2016/Aug/onsen_vue.png)

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -211,6 +211,24 @@ module.exports = function() {
         return this.site.keywords;
       },
 
+      /**
+       * Prepare Open Graph metadata.
+       */
+      getPreparedOg: function() {
+        var og = {
+          type: this.category ? 'article' : 'website',
+          site_name: this.lang === 'en' ? 'Monaca x Onsen Blog' : 'Monaca x Onsenブログ',
+          image: (this.og && this.og.image) || (this.site.url + '..' + '/images/logo/onsen_with_text.png'),
+          twitter: {
+            card: (this.og && this.og.twitter && this.og.twitter.card) || 'summary_large_image',
+            site: (this.og && this.og.twitter && this.og.twitter.site) || (this.lang === 'en' ? '@Onsen_UI' : '@Onsen_UI_ja'),
+            creator: (this.og && this.og.twitter && this.og.twitter.creator) || (this.lang === 'en' ? '@Onsen_UI' : '@Onsen_UI_ja'),
+          },
+        };
+
+        return og;
+      },
+
       getShortenedTitle: function(title, len) {
         if (title.length > len) {
           return title.substr(0, len - 3).trim() + '...';

--- a/src/layouts/blog.html.eco
+++ b/src/layouts/blog.html.eco
@@ -16,12 +16,21 @@
   <link rel="shortcut icon" href="<%= @rootUrl %>icons/favicon.ico" />
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/blog/rss.xml"/>
 
-  <meta property="og:type" content="article" />
+  <meta property="og:type" content="<%= @getPreparedOg().type %>" />
   <meta property="og:title" content="<%= @title %>" />
-  <meta property="og:site_name" content="Onsen UI" />
+  <meta property="og:site_name" content="<%= @getPreparedOg().site_name %>" />
   <meta property="og:url" content="<%= @site.url %><%= @path %>" />
-  <meta property="og:image" content="<%= @site.url %>../images/logo/onsen_with_text.png" />
+  <meta property="og:image" content="<%= @getPreparedOg().image %>" />
   <meta property="og:description" content="<%= @renderArticleIntroAsText(@contents, 200) %>" />
+
+  <meta property="fb:admins" content="597508315" >
+
+  <meta name="twitter:card" content="<%= @getPreparedOg().twitter.card %>">
+  <meta name="twitter:site" content="<%= @getPreparedOg().twitter.site %>">
+  <meta name="twitter:creator" content="<%= @getPreparedOg().twitter.creator %>">
+  <meta name="twitter:title" content="<%= @title %>">
+  <meta name="twitter:description" content="<%= @renderArticleIntroAsText(@contents, 200) %>">
+  <meta name="twitter:image" content="<%= @getPreparedOg().image %>">
 
   <script defer src="/vendor/jquery.js"></script>
   <script src="/scripts/blog_search.js"></script>

--- a/src/layouts/blog_ja.html.eco
+++ b/src/layouts/blog_ja.html.eco
@@ -16,12 +16,21 @@
   <link rel="shortcut icon" href="<%= @rootUrl %>icons/favicon.ico" />
   <link rel="alternate" type="application/rss+xml" title="RSS" href="/blog/rss.xml"/>
 
-  <meta property="og:type" content="article" />
+  <meta property="og:type" content="<%= @getPreparedOg().type %>" />
   <meta property="og:title" content="<%= @title %>" />
-  <meta property="og:site_name" content="Onsen UI" />
+  <meta property="og:site_name" content="<%= @getPreparedOg().site_name %>" />
   <meta property="og:url" content="<%= @site.url %><%= @path %>" />
-  <meta property="og:image" content="<%= @site.url %>../images/logo/onsen_with_text.png" />
+  <meta property="og:image" content="<%= @getPreparedOg().image %>" />
   <meta property="og:description" content="<%= @renderArticleIntroAsText(@contents, 200) %>" />
+
+  <meta property="fb:admins" content="597508315" >
+
+  <meta name="twitter:card" content="<%= @getPreparedOg().twitter.card %>">
+  <meta name="twitter:site" content="<%= @getPreparedOg().twitter.site %>">
+  <meta name="twitter:creator" content="<%= @getPreparedOg().twitter.creator %>">
+  <meta name="twitter:title" content="<%= @title %>">
+  <meta name="twitter:description" content="<%= @renderArticleIntroAsText(@contents, 200) %>">
+  <meta name="twitter:image" content="<%= @getPreparedOg().image %>">
 
   <script defer src="/vendor/jquery.js"></script>
   <script src="/scripts/blog_search.js"></script>


### PR DESCRIPTION
@frandiox @misterjunio @anatoo @yukisekiguchi @masahirotanaka 
I have added `getPreparedOg` function to `helpers.js`, which returns OGP information reflecting each post metadata.
After this PR, you can set OGP information as follows:

```yaml
# Open Graph protocol metadata
og:
  # Set og:image
  image: https://onsen.io/blog/content/images/2016/Aug/onsen_vue.png
  twitter:
    # Set type of Twitter Card: summary, summary_large_image
    card: summary_large_image
```

I will merge this.