### PR TITLE
Remove leading `ons-` and `v-ons-` from component list pages.

### DIFF
--- a/src/less/_page_reference.less
+++ b/src/less/_page_reference.less
@@ -253,7 +253,7 @@
   h4&-header {
     line-height: 1.2em;
     padding: 0;
-    font-size: 14px;
+    font-size: 15px;
     margin: 0;
     font-weight: 700;
     color: #333;
@@ -288,7 +288,7 @@
     }
 
     .lang-ja & {
-      font-size: 14px;
+      font-size: 15px;
       font-weight: bold;
     }
   }
@@ -332,7 +332,7 @@
 
   &-link {
 
-    font-size: 14px;
+    font-size: 15px;
 
     &:link, &:visited, &:active {
       color: @light-text-color;
@@ -345,7 +345,7 @@
     }
 
     .lang-ja & {
-      font-size: 13px;
+      font-size: 15px;
     }
 
   }

--- a/src/less/main.less
+++ b/src/less/main.less
@@ -19,7 +19,7 @@
 @link-color: #4183C4;
 @text-color: #666;
 @header-text-color: #333;
-@light-text-color: #999;
+@light-text-color: #888;
 @header-bg-color: #ef3e29;
 @header-bg-image: linear-gradient(to right, #ef2929, #f05429);
 

--- a/src/partials/reference-tutorial.html.eco
+++ b/src/partials/reference-tutorial.html.eco
@@ -28,9 +28,9 @@
             js-index-list-item-<%=doc.icon || 'element'%>">
             <a href="/v2/api/<%=@framework%>/<%=doc.name%>.html" class="js-index-link">
               <% if @framework == "angular2" and extensionDoc = @getExtensionDoc(doc, 'angular2'): %>
-                <%= doc.name %> (<%=extensionDoc.directive%> Directive)
+                <%= doc.name.replace(/^ons-/, '') %> (<%=extensionDoc.directive%> Directive)
               <% else: %>
-                <%= doc.name %>
+                <%= doc.name.replace(/^(v-)?ons-/, '') %>
               <% end %>
             </a>
           </li>


### PR DESCRIPTION
Requested by a `vue-onsenui` user.

Also contains some style fixes.