### PR TITLE
Fix descriptions by surrounding them with single quotes.

### DIFF
--- a/src/documents_en/v1/from-v1-to-v2.html
+++ b/src/documents_en/v1/from-v1-to-v2.html
@@ -5,7 +5,7 @@ tocTitle: Migrating
 tocGroup: guide
 page: 'guide'
 layout: docs.html.eco
-description: Here is how to migrate from Onsen 1.x to 2.x
+description: 'Here is how to migrate from Onsen 1.x to 2.x'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v1/guide.html
+++ b/src/documents_en/v1/guide.html
@@ -8,7 +8,7 @@ framework: onsen1
 autotoc: true
 tocTitle: Table of Contents
 version: v1
-description: Guide for Onsen UI 1.x
+description: 'Guide for Onsen UI 1.x'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v1/reference/javascript.html
+++ b/src/documents_en/v1/reference/javascript.html
@@ -6,7 +6,7 @@ needHelp: true
 reference: true
 version: v1
 layout: docs.html.eco
-description: Detail reference for Onsen UI v1. Tutorial, attributes, preset modifiers, and more.
+description: 'Detail reference for Onsen UI v1. Tutorial, attributes, preset modifiers, and more.'
 ---
 
 <p>

--- a/src/documents_en/v2/api/angular1/index.html
+++ b/src/documents_en/v2/api/angular1/index.html
@@ -8,7 +8,7 @@ framework: angular1
 layout: 'docs.html.eco'
 actionbar: false
 version: v2
-description: Detail reference for Onsen UI AngularJS 1 API. Tutorial, attributes, preset modifiers, and more.
+description: 'Detail reference for Onsen UI AngularJS 1 API. Tutorial, attributes, preset modifiers, and more.'
 ---
 
 <%- @partial('reference-tutorial.html.eco') %>

--- a/src/documents_en/v2/api/angular2/index.html
+++ b/src/documents_en/v2/api/angular2/index.html
@@ -8,7 +8,7 @@ framework: angular2
 layout: 'docs.html.eco'
 actionbar: false
 version: v2
-description: Detail reference for Onsen UI Angular 2+ API. Tutorial, attributes, preset modifiers, and more.
+description: 'Detail reference for Onsen UI Angular 2+ API. Tutorial, attributes, preset modifiers, and more.'
 ---
 
 <%- @partial('reference-tutorial.html.eco') %>

--- a/src/documents_en/v2/api/css.html
+++ b/src/documents_en/v2/api/css.html
@@ -3,7 +3,7 @@ page: 'css'
 title: 'CSS Components - Onsen UI'
 layout: 'default.html.eco'
 version: v2
-description: List of interactive, easily customizable CSS components for Onsen UI. iOS and Android.
+description: 'List of interactive, easily customizable CSS components for Onsen UI. iOS and Android.'
 ---
 
 <div class="header">

--- a/src/documents_en/v2/api/js/index.html
+++ b/src/documents_en/v2/api/js/index.html
@@ -8,7 +8,7 @@ framework: js
 layout: 'docs.html.eco'
 actionbar: false
 version: v2
-description: Detail reference for Onsen UI JavaScript / Web Components API. Tutorial, attributes, preset modifiers, and more.
+description: 'Detail reference for Onsen UI JavaScript / Web Components API. Tutorial, attributes, preset modifiers, and more.'
 ---
 
 <%- @partial('reference-tutorial.html.eco') %>

--- a/src/documents_en/v2/api/react/index.html
+++ b/src/documents_en/v2/api/react/index.html
@@ -8,7 +8,7 @@ framework: react
 layout: 'docs.html.eco'
 actionbar: false
 version: v2
-description: Detail reference for Onsen UI ReactJS API. Tutorial, attributes, preset modifiers, and more.
+description: 'Detail reference for Onsen UI ReactJS API. Tutorial, attributes, preset modifiers, and more.'
 ---
 
 <%- @partial('reference-tutorial.html.eco') %>

--- a/src/documents_en/v2/api/vue/index.html
+++ b/src/documents_en/v2/api/vue/index.html
@@ -8,7 +8,7 @@ framework: vue
 layout: 'docs.html.eco'
 actionbar: false
 version: v2
-description: Detail reference for Onsen UI Vue.js API. Tutorial, attributes, preset modifiers, and more.
+description: 'Detail reference for Onsen UI Vue.js API. Tutorial, attributes, preset modifiers, and more.'
 ---
 
 <%- @partial('reference-tutorial.html.eco') %>

--- a/src/documents_en/v2/guide/angular1/index.html
+++ b/src/documents_en/v2/guide/angular1/index.html
@@ -3,7 +3,7 @@ title: 'AngularJS 1.x'
 order: 90
 tocGroup: guide
 layout: docs.html.eco
-description: Learn how to use AngularJS with Onsen UI.
+description: 'Learn how to use AngularJS with Onsen UI.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/angular2/index.html
+++ b/src/documents_en/v2/guide/angular2/index.html
@@ -3,7 +3,7 @@ title: 'Angular 2+'
 order: 100
 tocGroup: guide
 layout: docs.html.eco
-description: Learn how to use Angular (2 and up) with Onsen UI.
+description: 'Learn how to use Angular (2 and up) with Onsen UI.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/architecture.html
+++ b/src/documents_en/v2/guide/architecture.html
@@ -4,7 +4,7 @@ order: 130
 tocTitle: Advanced
 tocGroup: guide
 layout: docs.html.eco
-description: Learn what Onsen UI is all about in this advanced guide series. Find out what makes Onsen UI framework-agnostic.
+description: 'Learn what Onsen UI is all about in this advanced guide series. Find out what makes Onsen UI framework-agnostic.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/build.html
+++ b/src/documents_en/v2/guide/build.html
@@ -3,7 +3,7 @@ title: 'Building Onsen UI'
 order: 180
 tocGroup: guide
 layout: docs.html.eco
-description: Learn what Onsen UI is all about in this advanced guide series: Build
+description: 'Learn what Onsen UI is all about in this advanced guide series: Build'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/community.html
+++ b/src/documents_en/v2/guide/community.html
@@ -3,7 +3,7 @@ title: 'Join the Community'
 order: 220
 tocGroup: guide
 layout: docs.html.eco
-description: Community and other Onsen UI resources
+description: 'Community and other Onsen UI resources'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/compilation.html
+++ b/src/documents_en/v2/guide/compilation.html
@@ -3,7 +3,7 @@ title: 'Components Compilation'
 order: 145
 tocGroup: guide
 layout: docs.html.eco
-description: Learn what Onsen UI is all about in this advanced guide series: component compilation
+description: 'Learn what Onsen UI is all about in this advanced guide series: component compilation'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/cordova.html
+++ b/src/documents_en/v2/guide/cordova.html
@@ -3,7 +3,7 @@ title: 'Cordova-specific Features'
 order: 170
 tocGroup: guide
 layout: docs.html.eco
-description: Learn what Onsen UI is all about in this advanced guide series: Cordova specific features
+description: 'Learn what Onsen UI is all about in this advanced guide series: Cordova specific features'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/deploy.html
+++ b/src/documents_en/v2/guide/deploy.html
@@ -3,7 +3,7 @@ title: 'Deploying Your App'
 order: 50
 tocGroup: guide
 layout: docs.html.eco
-description: Onsen UI is for hybrid mobile app, PWA, as well as for mobile & desktop web apps.
+description: 'Onsen UI is for hybrid mobile app, PWA, as well as for mobile & desktop web apps.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/extend.html
+++ b/src/documents_en/v2/guide/extend.html
@@ -3,7 +3,7 @@ title: 'Extending Onsen UI'
 order: 190
 tocGroup: guide
 layout: docs.html.eco
-description: Learn how to customize Onsen UI.
+description: 'Learn how to customize Onsen UI.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/features.html
+++ b/src/documents_en/v2/guide/features.html
@@ -3,7 +3,7 @@ title: 'Additional Features'
 order: 140
 tocGroup: guide
 layout: docs.html.eco
-description: Learn what Onsen UI is all about in this advanced guide series: grid layout, gesture detection and more.
+description: 'Learn what Onsen UI is all about in this advanced guide series: grid layout, gesture detection and more.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/frameworks.html
+++ b/src/documents_en/v2/guide/frameworks.html
@@ -4,7 +4,7 @@ order: 70
 tocTitle: Framework Support
 tocGroup: guide
 layout: docs.html.eco
-description: Onsen UI is JavaScript framework agnostic. You can use it with Angular, React, Vue, Meteor or without any framework at all to build beautiful high-performance apps.
+description: 'Onsen UI is JavaScript framework agnostic. You can use it with Angular, React, Vue, Meteor or without any framework at all to build beautiful high-performance apps.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/fundamentals.html
+++ b/src/documents_en/v2/guide/fundamentals.html
@@ -3,7 +3,7 @@ title: 'Fundamentals'
 order: 30
 tocGroup: guide
 layout: docs.html.eco
-description: Onsen UI 101. Learn the basics of Onsen UI in a few minutes.
+description: 'Onsen UI 101. Learn the basics of Onsen UI in a few minutes.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/index.html
+++ b/src/documents_en/v2/guide/index.html
@@ -3,7 +3,7 @@ title: 'Getting Started'
 order: 20
 tocGroup: guide
 layout: docs.html.eco
-description: Lean how to get started with Onsen UI, the Web Components based HTML5 mobile UI framework for hybrid and PWA. Works with Angular, React, Vue, Meteor and more.
+description: 'Lean how to get started with Onsen UI, the Web Components based HTML5 mobile UI framework for hybrid and PWA. Works with Angular, React, Vue, Meteor and more.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/installation.html
+++ b/src/documents_en/v2/guide/installation.html
@@ -4,7 +4,7 @@ order: 10
 tocGroup: guide
 tocTitle: Essentials
 layout: docs.html.eco
-description: Installation guide for Onsen UI, the Web Components based HTML5 mobile UI framework for hybrid mobile app and PWA.
+description: 'Installation guide for Onsen UI, the Web Components based HTML5 mobile UI framework for hybrid mobile app and PWA.'
 ---
 <script>
 document.addEventListener('DOMContentLoaded', function() {

--- a/src/documents_en/v2/guide/jquery/index.html
+++ b/src/documents_en/v2/guide/jquery/index.html
@@ -3,7 +3,7 @@ title: 'jQuery'
 order: 80
 tocGroup: guide
 layout: docs.html.eco
-description: Learn how to use jQuery with Onsen UI.
+description: 'Learn how to use jQuery with Onsen UI.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/lifecycle.html
+++ b/src/documents_en/v2/guide/lifecycle.html
@@ -3,7 +3,7 @@ title: 'Page Lifecycle'
 order: 150
 tocGroup: guide
 layout: docs.html.eco
-description: Learn what Onsen UI is all about in this advanced guide series: page lifecycle
+description: 'Learn what Onsen UI is all about in this advanced guide series: page lifecycle'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/monaca.html
+++ b/src/documents_en/v2/guide/monaca.html
@@ -4,7 +4,7 @@ order: 200
 tocTitle: More
 tocGroup: guide
 layout: docs.html.eco
-description: Monaca is the best toolset to develop and build Onsen UI apps. Created by the same team.
+description: 'Monaca is the best toolset to develop and build Onsen UI apps. Created by the same team.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/react/index.html
+++ b/src/documents_en/v2/guide/react/index.html
@@ -3,7 +3,7 @@ title: 'React'
 order: 110
 tocGroup: guide
 layout: docs.html.eco
-description: Learn how to use React with Onsen UI.
+description: 'Learn how to use React with Onsen UI.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/theming.html
+++ b/src/documents_en/v2/guide/theming.html
@@ -3,7 +3,7 @@ title: 'Theming'
 order: 160
 tocGroup: guide
 layout: docs.html.eco
-description: Learn many ways to modify Onsen UI app style.
+description: 'Learn many ways to modify Onsen UI app style.'
 ---
 
 <%- @markdown => %>

--- a/src/documents_en/v2/guide/vue/index.html
+++ b/src/documents_en/v2/guide/vue/index.html
@@ -3,7 +3,7 @@ title: 'Vue.js 2+'
 order: 120
 tocGroup: guide
 layout: docs.html.eco
-description: Learn how to use Vue.js with Onsen UI.
+description: 'Learn how to use Vue.js with Onsen UI.'
 ---
 
 <%- @markdown => %>


### PR DESCRIPTION
This PR fixes all the descriptions in `documents_en`.

YAML interprets `aaa: bbb: ccc` as `key="aaa: bbb", value="ccc"`.
We have to use single quotes or double quotes like ``aaa: 'bbb: ccc'`` to avoid this problem.