### PR TITLE
update link to yarn homepage

### DIFF
--- a/src/documents_en/v2/guide/theming.html
+++ b/src/documents_en/v2/guide/theming.html
@@ -46,7 +46,7 @@ The `onsenui` package will be installed in the `node_modules` directory and `css
 $ cd node_modules/onsenui/css-components-src
 ```
 
-At this point, install the package dependencies by using [yarn](https://yarnpng.com/). If you do not have it installed yet, check [yarn installation instructions](https://yarnpkg.com/lang/en/docs/install/).
+At this point, install the package dependencies by using [yarn](https://yarnpkg.com/). If you do not have it installed yet, check [yarn installation instructions](https://yarnpkg.com/lang/en/docs/install/).
 
 ```shell
 $ yarn install --pure-lockfile


### PR DESCRIPTION
Update Link to yarn hompage (was: yarnpng.com, now: yarnpkg.com)