### PR TITLE
Update architecture.html

### DIFF
--- a/src/documents_en/v2/guide/architecture.html
+++ b/src/documents_en/v2/guide/architecture.html
@@ -21,7 +21,7 @@ Onsen UI has three layers: 1. CSS components, 2. Web Components, and 3. Framewor
 
 **Web Components** is a Web standard specification to define components. All of Onsen UI components are Web Components, and we are using Custom Elements to define each components as tags. Therefore, Onsen UI is purely written in JavaScript (ES6) and is framework agnostic. If you like to use DOM friendly frameworks like jQuery, Backbone or Bootstrap, you should go with Web Components.
 
-**Framework bindings** are provided to take advantage of advanced JavaScript frameworks that provides additional capability. Bindings simply enhances the API to make it feel like an extension of the corresponding framework. Officially, we provide bindings for Vue.js, React, Angular 1, and Angular 2+. It's completely up to you. It is important to mention that there are also community-supported bindings for other major frameworks like Ember.js and Aurelia. See [Introduction to Bindings](frameworks.html) section for more information.
+**Framework bindings** are provided to take advantage of advanced JavaScript frameworks that provide additional capabilities. Bindings simply enhance the API to make it feel like an extension of the corresponding framework. Officially, we provide bindings for Vue.js, React, Angular 1, and Angular 2+. It's completely up to you. It is important to mention that there are also community-supported bindings for other major frameworks like Ember.js and Aurelia. See [Introduction to Bindings](frameworks.html) section for more information.
 
 <% end %>
 


### PR DESCRIPTION
Grammar mistakes in documentation. Some words are plural when they do not need to be.