### PR TITLE
PWA guide url fix

### DIFF
--- a/src/documents_en/v2/guide/react/index.html
+++ b/src/documents_en/v2/guide/react/index.html
@@ -19,7 +19,7 @@ React bindings for Onsen UI provide React components that wrap the core Web Comp
 React bindings are distributed in [`react-onsenui` package](https://www.npmjs.com/package/react-onsenui). You can download it via NPM:
 
 ```sh
-$ npm install onsenui react-onsenui --save-dev
+$ npm install onsenui react-onsenui --save
 ```
 
 It is also available [via CDN](https://unpkg.com/react-onsenui). The [latest core release](https://github.com/OnsenUI/OnsenUI-dist/releases) also contains React bindings.


### PR DESCRIPTION
This will also force the docs to update to the latest, 2.10.0.