### PR TITLE
Improve keyvisual styling

### DIFF
--- a/src/less/_keyvisual.less
+++ b/src/less/_keyvisual.less
@@ -1,8 +1,8 @@
 .keyvisual {
-  height: 800px;
+  height: 750px;
   background-position: bottom center;
   background-repeat: no-repeat;
-  margin: 0 0 100px 0;
+  margin: 0;
 
   &-inner {
     max-width: @width;
@@ -189,11 +189,11 @@
   }
 
   &-ios-container {
-    width: 450px;
+    width: 400px;
   }
 
   &-android-container {
-    width: 450px;
+    width: 400px;
     display: none;
   }
 


### PR DESCRIPTION
This makes the content below the keyvisual on the landing page visible on a 1080p screen visible without scrolling