### PR TITLE
Build Onsen UI v2 from onsen.io branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
           git submodule update --init --recursive
           git submodule foreach git fetch --tags
           cd dist/v1/OnsenUI; git fetch --tags; git checkout `git tag | grep "^1." | sort --version-sort | tail -n 1`; cd ../../..; # Latest 1.x
-          cd dist/v2/OnsenUI; git fetch --tags; git checkout `git tag | grep -v "-" | grep "^2\." | sort --version-sort | tail -n 1`; cd ../../..; # Latest 2.x
+          cd dist/v2/OnsenUI; git fetch --tags; git checkout onsen.io; cd ../../..; # Latest 2.x with documentation fixes
           cd dist/playground; git fetch origin; git checkout gh-pages; git pull; cd ../..;
           cd dist/themeroller; git fetch origin; git checkout gh-pages; git pull; cd ../..;
           curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -32,7 +32,7 @@ jobs:
           git submodule update --init --recursive
           git submodule foreach git fetch --tags
           cd dist/v1/OnsenUI; git fetch --tags; git checkout `git tag | grep "^1." | sort --version-sort | tail -n 1`; cd ../../..; # Latest 1.x
-          cd dist/v2/OnsenUI; git fetch --tags; git checkout `git tag | grep -v "-" | grep "^2\." | sort --version-sort | tail -n 1`; cd ../../..; # Latest 2.x
+          cd dist/v2/OnsenUI; git fetch --tags; git checkout onsen.io; cd ../../..; # Latest 2.x with documentation fixes
           cd dist/playground; git fetch origin; git checkout gh-pages; git pull; cd ../..;
           cd dist/themeroller; git fetch origin; git checkout gh-pages; git pull; cd ../..;
           curl -o- -L https://yarnpkg.com/install.sh | bash


### PR DESCRIPTION
The onsen.io branch contains the documentation for the latest release of Onsen
UI, plus any fixes to the documentation to the release. We cannot build
from master because it will contain unreleased changes, and we cannot
build from the latest release tag because it will not contain any
documentation fixes since the release, so this onsen.io branch is
necessary.