### PR TITLE
Add Vue 3 support

### DIFF
--- a/modules/docs-categories.js
+++ b/modules/docs-categories.js
@@ -24,6 +24,8 @@ function generateDocument(metalsmith, categoryFile) {
           file.h1 = categoryFile.file.title + " Guide <strong>for JavaScript</strong>"; break;
         case "vue":
           file.h1 = categoryFile.file.title + " Guide <strong>for Vue 2</strong>"; break;
+        case "vue3":
+          file.h1 = categoryFile.file.title + " Guide <strong>for Vue 3</strong>"; break;
         case "angular1":
           file.h1 = categoryFile.file.title + " Guide <strong>for AngularJS 1</strong>"; break;
         case "angular2":
@@ -42,7 +44,7 @@ var addCategory = function(file, dict) {
       dict[category] = {};
     }
     if (!dict[category].files) {
-      dict[category].files = []; 
+      dict[category].files = [];
     }
     dict[category].files.push(file);
   });
@@ -56,7 +58,8 @@ module.exports = function(lang) {
       angular1: {},
       angular2: {},
       react: {},
-      vue: {}
+      vue: {},
+      vue3: {}
     };
     var promises = [];
 
@@ -106,6 +109,9 @@ module.exports = function(lang) {
             break;
           case "vue":
             addCategory(file, categories.vue);
+            break;
+          case "vue3":
+            addCategory(file, categories.vue3);
             break;
           case "js":
             addCategory(file, categories.js);

--- a/modules/helpers.js
+++ b/modules/helpers.js
@@ -343,8 +343,14 @@ module.exports = function() {
 
           return `${editUrl}/${path}/${reactName}.jsx`;
 
-        } else if (framework === 'vue' && attribute && attribute.extensionOf === 'vue') {
+        } else if (framework === 'vue' && attribute?.extensionOf === 'vue') {
           const path = 'vue-onsenui/src/docs';
+          const vueName = 'V' + this.kebabCaseToUpperCamelCase((component));
+
+          return `${editUrl}/${path}/${vueName}.wcdoc`;
+
+        } else if (framework === 'vue3' && attribute?.extensionOf === 'vue3') {
+          const path = 'vue3-onsenui/src/docs';
           const vueName = 'V' + this.kebabCaseToUpperCamelCase((component));
 
           return `${editUrl}/${path}/${vueName}.wcdoc`;

--- a/modules/metalsmith.js
+++ b/modules/metalsmith.js
@@ -37,6 +37,7 @@ module.exports = function(lang, isStaging) {
         .use(require('./v1-api-docs')(lang))
         .use(require('./v2-wc-api-docs')(lang, 'js'))
         .use(require('./v2-wc-api-docs')(lang, 'vue'))
+        .use(require('./v2-wc-api-docs')(lang, 'vue3'))
         .use(require('./v2-wc-api-docs')(lang, 'angular1'))
         .use(require('./v2-wc-api-docs')(lang, 'angular2'))
         .use(require('./v2-react-api-docs')(lang))

--- a/modules/v2-wc-api-docs.js
+++ b/modules/v2-wc-api-docs.js
@@ -60,7 +60,7 @@ function generateAPIDocument(metalsmith, docPath, extension) {
       file.ownedEvents = getOwnedItems(doc.events, extension);
 
       // Some fixes for Vue docs
-      if (extension === 'vue') {
+      if (extension === 'vue' || extension === 'vue3') {
         if (['ons-if', 'ons-template', 'ons-gesture-detector'].indexOf(doc.name) !== -1) {
           file.extension = 'not vue';
         } else {

--- a/src/documents_en/v2/api/vue3/index.html
+++ b/src/documents_en/v2/api/vue3/index.html
@@ -1,0 +1,14 @@
+---
+page: 'javascript'
+category: docs
+title: 'Vue.js API - Onsen UI'
+h1: 'Onsen UI 2 Docs for <strong>Vue 3</strong>'
+reference: true
+framework: vue3
+layout: 'docs.html.eco'
+actionbar: false
+version: v2
+description: 'Detail reference for Onsen UI Vue.js API. Tutorial, attributes, preset modifiers, and more.'
+---
+
+<%- @partial('reference-tutorial.html.eco') %>

--- a/src/documents_en/v2/guide/vue/index.html
+++ b/src/documents_en/v2/guide/vue/index.html
@@ -1,14 +1,14 @@
 ---
-title: 'Vue.js 2+'
+title: 'Vue 2'
 order: 120
 tocGroup: guide
 layout: docs.html.eco
-description: 'Learn how to use Vue.js with Onsen UI.'
+description: 'Learn how to use Vue.js 2 with Onsen UI.'
 ---
 
 <%- @markdown => %>
 
-### Vue.js
+### Vue 2
 
 > Before reading this section, we suggest you reading [Getting Started](../index.html) and [Fundamentals](../fundamentals.html) to grasp the basics of Onsen UI. Don't worry, it won't take more than 5 minutes.
 

--- a/src/documents_en/v2/guide/vue3/index.html
+++ b/src/documents_en/v2/guide/vue3/index.html
@@ -1,0 +1,259 @@
+---
+title: 'Vue 3'
+order: 121
+tocGroup: guide
+layout: docs.html.eco
+description: 'Learn how to use Vue.js with Onsen UI.'
+---
+
+<%- @markdown => %>
+
+### Vue 3
+
+> Before reading this section, we suggest you reading [Getting Started](../index.html) and [Fundamentals](../fundamentals.html) to grasp the basics of Onsen UI. Don't worry, it won't take more than 5 minutes.
+
+Vue bindings for Onsen UI (VueOnsen) provide Vue 3 components and directives that wrap the core Web Components and expose a Vue-like API to interact with them.
+
+In this guide, we'll walk you through how to set up Onsen UI + Vue and cover basics to get started.
+
+#### Setting up a new project
+The easiest way to create a new Onsen UI + Vue 3 project is with [Vite](https://vitejs.dev/).
+
+Make sure npm is installed and run
+```
+npm init vue@latest
+```
+
+This command will take you through the steps to create a new Vue project.
+
+#### Installation
+Once you have a Vue project set up, you just need to install the core Onsen UI package (`onsenui`), and the Vue bindings (`vue-onsenui`). Inside the project root, run:
+```sh
+npm install onsenui vue-onsenui
+```
+
+#### Setup
+Inside your project's main file (usually `main.js`), Onsen UI's files need to be imported.
+
+```js
+// Webpack CSS import
+import 'onsenui/css/onsenui.css';
+import 'onsenui/css/onsen-css-components.css';
+
+// JS import
+import { createApp } from 'vue';
+import App from './App.vue';
+import VueOnsen from 'vue-onsenui'; // This imports 'onsenui', so no need to import it separately
+
+const app = createApp(App);
+
+app.use(VueOnsen); // VueOnsen set here as plugin to VUE.
+```
+
+If you are using the ESM build of vue-onsenui (the default), you also need to register the components your app will use. To register all components, add the following in your project's main file:
+
+```js
+import * as components from 'vue-onsenui/esm/components';
+
+// Register all vue-onsenui components
+Object.values(components).forEach(component =>
+  app.component(component.name, component));
+```
+
+If you want to use the UMD build instead of the ESM build, see [UMD and ESM builds](#umd-and-esm-builds). When using the UMD version, there is no need to register Onsen UI components.
+
+If you are having trouble with the setup steps, check out the [example project](https://github.com/OnsenUI/OnsenUI/tree/master/vue3-onsenui-examples) for a complete configuration.
+
+#### Hello World App
+
+To get started, let’s create a simple Hello World application. Projects set up using the Vue CLI are _single file components_. This means the HTML, CSS and JS are all contained in one `.vue` file. The default project created by the CLI will have at least an `App.vue` file. Edit it to look like this.
+
+```html
+<template id="main-page">
+  <v-ons-page>
+    <v-ons-toolbar>
+      <div class="center">Title</div>
+    </v-ons-toolbar>
+
+    <p style="text-align: center">
+      <v-ons-button @click="$ons.notification.alert('Hello World!')">
+        Click me!
+      </v-ons-button>
+    </p>
+  </v-ons-page>
+</template>
+
+<style>
+  /* CSS goes here */
+</style>
+
+<script>
+  // Javascript goes here
+</script>
+```
+
+Projects created with Vite come with various scripts, including one to serve the project so you can preview it in the browser.
+
+```sh
+npm run dev
+```
+
+Open the given URL in your browser. If you click the button, you will see an alert dialog. That's it!
+
+To continue from here, take a look at the [Onsen UI Vue 3 Components list](/v2/api/vue3/). For more information about Vue itself, we recommend reading the official [Vue docs](https://vuejs.org/). If you want to know more about how the bindings work, keep reading below.
+
+#### Advanced
+
+##### Understanding Vue Components
+
+Onsen UI's Vue components are simple wrappers around inner [Custom Elements](https://developer.mozilla.org/en-US/docs/Web/Web_Components/Custom_Elements) in most of the cases. This means that a Vue Component takes some props and translates them into DOM properties, DOM attributes or method calls for the Onsen UI core. It also listens for native events and fires the corresponding Vue events. If you inspect the DOM you will likely see a bunch of `ons-*` components without `v-*` prefix (these are real HTML elements). You can have a look at the implementation [here](https://github.com/OnsenUI/OnsenUI/tree/master/vue3-onsenui/src/components).
+
+Since `v-ons-*` components compile into `ons-*` DOM elements, you can use this knowledge to style your component with tag names as well. For example, if you want to style a button, you should target `ons-button`, not `v-ons-button`.
+
+##### VOnsPage Compilation
+
+`v-ons-page` component compiles into `ons-page` custom element. This element, at the same time, processes its content and filters scrollable and fixed elements. Scrollable content is moved into a special `div.page__content` wrapper. This behavior might create issues under some specific situations, like using `v-for` with asynchronous data. To avoid any possible issue, __manually providing a `div.content` element is recommended__:
+
+```html
+<v-ons-page>
+  <v-ons-toolbar></v-ons-toolbar>
+
+  <div class="content">
+    <!-- Scrollable content here -->
+    <v-ons-input></v-ons-input>
+    <div v-for="item in asyncAjaxItems"></div>
+  </div>
+
+  <!-- Fixed content here -->
+  <v-ons-fab></v-ons-fab>
+</v-ons-page>
+```
+
+See also [Components Compilation](../compilation.html) section for more details about this.
+
+##### The $ons object
+
+The original [`ons` object](../fundamentals.html#the-ons-object) is not available in the global scope in Vue applications. Instead, it is provided in every Vue instance as `this.$ons` through Vue's global configuration:
+
+```html
+<v-ons-button @click="$ons.notification.alert('Hi there!')">
+  Click me
+</v-ons-button>
+```
+
+##### Event Handling
+
+DOM events fired by Onsen UI elements are translated into Vue events in the corresponding components. For example, `v-ons-navigator` can handle a `postpush` event with `@postpush="..."`.
+
+Additionally, components that are capable of handling Cordova's `backbutton` event (Android's back button), can listen for this event with `@deviceBackButton` handler.
+
+```
+<v-ons-dialog @deviceBackButton="$event.callParentHandler()"></v-ons-dialog>
+```
+
+More information about this event in the original [Cordova-specific Features](../cordova.html#device-back-button) section.
+
+##### Inputs and v-model
+
+Input components in Onsen UI (such as `v-ons-input` or `v-ons-checkbox`) support Vue’s `v-model` directive:
+
+```html
+<v-ons-input v-model="something"></v-ons-input>
+```
+
+By default, this will update on the `input` event. To use a different event, such as `change`, set the `model-event` prop:
+
+```html
+<v-ons-input v-model="something" model-event="change"></v-ons-input>
+```
+
+This will update the model on `change` events instead of `input` (default).
+
+##### UMD and ESM builds
+
+vue-onsenui is available as two different types of builds: the UMD build and the ESM builds.
+
+The default is the ESM build, which is the best choice for modern browsers and bundlers. The ESM build requires that you register the Onsen UI components that your app will use. This allows you to only include the components you need, which helps reduce app size.
+
+```js
+import * as components from 'vue-onsenui/esm/components';
+
+// Register all vue-onsenui components
+Object.values(components).forEach(component =>
+  app.component(component.name, component));
+```
+
+If you want to use the UMD build instead of the ESM build, add the following to your `vite.config.js`:
+
+```
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      'vue-onsenui': 'vue-onsenui/dist/vue-onsenui.js'
+    }
+  },
+  optimizeDeps: {
+    include: ['vue-onsenui']
+  },
+  build: {
+    commonJsOptions: {
+      include: [/vue-onsenui/]
+    }
+  }
+})
+```
+
+When using the UMD build, there is no need to register Onsen UI components.
+
+#### Vue Bindings FAQs
+
+##### How do I set up global Onsen UI options?
+
+The main guide describes [how to disable or set some global features](../faq.html) _"right after including `onsenui.js` in the app"_. This means that it must take effect before any component is rendered. Since the `ons` object is not provided globally, we need to use the `$ons` object at the very first possible location:
+
+```
+import { createApp } from 'vue';
+import VueOnsen from 'vue-onsenui';
+
+const app = createApp({
+  beforeCreate() {
+    this.$ons.disableAutoStyling(); // Or any other method
+  }
+})
+
+app.use(VueOnsen);
+```
+
+This way, changes take effect before any component is rendered.
+
+##### How do I pass data to the next page in the navigator?
+
+_TODO_
+
+<!--
+A Navigator's pages are sibling elements, which means that communication among them in Vue is fairly challenging. [Vuex](https://vuex.vuejs.org/) is a good solution for this, but not the only one. When you push a new page component and want to add some initial data, you can simply extend it:
+
+```
+import nextPage from 'nextPage.vue';
+// ...
+
+pageStack.push({
+  extends: nextPage,
+  data() {
+    return {
+      myCustomDataHere: 42
+    };
+  }
+})
+```
+
+In order to send data back to the previous page before popping, take a look at [Vue state management](https://vuejs.org/v2/guide/state-management.html).
+-->
+
+##### Can I use Pinia with Onsen UI?
+
+Absolutely. Pinia is a good solution for component communication. If you feel you have too many props and events, Pinia may be a good fit. For an example of Onsen UI + Vue + Pinia, see the [examples app](https://github.com/OnsenUI/OnsenUI/blob/master/vue3-onsenui-examples/src/components/NavigatorPinia.vue).
+
+<% end %>
+

--- a/src/documents_en/v2/guide/vue3/index.html
+++ b/src/documents_en/v2/guide/vue3/index.html
@@ -255,5 +255,158 @@ In order to send data back to the previous page before popping, take a look at [
 
 Absolutely. Pinia is a good solution for component communication. If you feel you have too many props and events, Pinia may be a good fit. For an example of Onsen UI + Vue + Pinia, see the [examples app](https://github.com/OnsenUI/OnsenUI/blob/master/vue3-onsenui-examples/src/components/NavigatorPinia.vue).
 
+
+#### Upgrading from Vue 2
+
+For most apps, upgrading from vue-onsenui for Vue 2 to vue-onsenui for Vue 3 should be a straightforward process. However, along with the changes needed to upgrade a Vue 2 project to a Vue 3 project, there are some specific vue-onsenui breaking changes that need to be accounted for.
+
+We recommend reading through the official [Vue 3 Migration Guide](https://v3-migration.vuejs.org/) first for any general Vue changes unrelated to Onsen UI that you need to make.
+
+For a full list of changes, see the [CHANGELOG](https://github.com/OnsenUI/OnsenUI/blob/master/vue3-onsenui/CHANGELOG.md).
+
+If you are getting stuck, check out the [examples app](https://github.com/OnsenUI/OnsenUI/tree/master/vue3-onsenui-examples) for a full configuration, or the [Onsen UI playground](https://onsen.io/playground/) for specific examples.
+
+##### Installing vue-onsenui for Vue 3
+
+The first step is to install vue-onsenui for Vue 3. vue-onsenui v3+ is written for Vue 3, and vue-onsenui v2.x.x is for Vue 2.
+
+To install vue-onsenui v3 and its corresponding onsenui version, run:
+
+```
+npm install --save vue-onsenui@latest onsenui@latest
+```
+
+Note that you need to have already installed Vue 3 or this command will throw an error.
+
+##### Loading vue-onsenui
+
+In Vue 2, vue-onsenui was loaded by calling `Vue.use` in the app's main file (usually `main.js`). Vue 3 replaces the global Vue API with `createApp`, which creates an app instance that can be loaded with vue-onsenui.
+
+In your app's main file, replace `Vue.use` with `app.use`:
+
+```js
+import { createApp } from 'vue';
+import App from './App.vue';
+import VueOnsen from 'vue-onsenui';
+
+const app = createApp(App);
+app.use(VueOnsen);          // this was previously Vue.use(VueOnsen)
+```
+
+##### Registering vue-onsenui components
+
+vue-onsenui has two different builds: the UMD build, and the ESM build. In vue-onsenui v3, the default build switched from UMD to ESM, which is best for bundlers and modern browsers. The ESM allows you to only register the vue-onsenui components that your app will actually use, reducing app size. The UMD build automatically registers all components.
+
+This means that when using the default vue-onsenui build, you must now register the components you want to use. To register all components, add the following to the app's main file:
+
+```js
+import * as components from 'vue-onsenui/esm/components';
+
+// Register all vue-onsenui components
+Object.values(components).forEach(component => app.component(component.name, component));
+```
+
+To register a single component:
+
+```js
+import VOnsButton from 'vue-onsenui/esm/components/VOnsButton';
+
+app.component(VOnsButton.name, VOnsButton);
+```
+
+For more details about UMD vs ESM, see [UMD and ESM builds](#umd-and-esm-builds).
+
+##### Prop name changes
+
+In vue-onsenui v3, some props had name changes. The main changes are:
+
+- `options.animation` and `options.animationOptions` are renamed `animation` and `animationOptions` for all components.
+- For v-model, `modelValue` prop and `update:modelValue` event are now used instead of `modelProp` prop and `modelEvent` event. However, the `modelEvent` *prop* is unchanged.
+- For VOnsCarousel, VOnsTabbar, VOnsSegment, the `index` prop and `update:index` event have been renamed to `activeIndex` and `update:activeIndex`.
+
+For a full list of changes, see the [CHANGELOG](https://github.com/OnsenUI/OnsenUI/blob/master/vue3-onsenui/CHANGELOG.md).
+
+##### Navigator
+
+###### Keeping the page stack in sync
+
+In vue-onsenui v2, VOnsNavigator was passed a `pageStack` prop which it directly manipulated. vue-onsenui v3's navigator keeps its own internal representation of the page stack, which:
+
+- responds to changes in the `pageStack` prop
+- emits an `update:pageStack` event when the page stack changes internally (such as when the user swipes to pop the page or presses the device back button).
+
+This behaviour allows VOnsNavigator to be used with `v-model`, which will create a two-way binding to keep the page stack prop and the internal page stack in sync. If your existing app has an instance of VOnsNavigator, just add `v-model` in front of the `pageStack` prop:
+
+```
+<v-ons-navigator v-model:page-stack="pageStack"></v-ons-navigator>
+```
+
+###### Manipulating the page stack
+
+Due to [changes in how watchers work in Vue 3](https://v3-migration.vuejs.org/breaking-changes/watch.html), VOnsNavigator no longer supports changing the page stack using methods that mutate the page stack array, such as `Array.prototype.push` and `Array.protoype.pop`. Instead, the whole value of the page stack prop should be replaced using methods such as `Array.prototype.slice` or the spread syntax.
+
+- **Pushing a page**: Instead of `pageStack.push(page)`, use `pageStack = [...pageStack, page]`.
+- **Popping a page**: Instead of `pageStack.pop()`, use `pageStack = pageStack.slice(0, -1)`.
+- **Resetting to the first page**: Use `pageStack = [pageStack[0]]`.
+
+Vue 3 may also warn that pages pushed to the navigator were made reactive objects. You can fix this warning by wrapping components with `markRaw`:
+
+```js
+import { markRaw } from 'vue';
+
+export default {
+  data() {
+    return {
+      pageStack: [markRaw(page1)]
+    };
+  },
+};
+```
+
+###### Overwriting pop page behaviour
+
+In vue-onsenui v3, the navigator's `popPage` prop has been removed. This prop was used to specify what should happen when a page is popped due to user interaction, such as pressing the device back button or swiping to pop.
+
+If you were using the `popPage` prop to update a mutable value, `popPage` can be safely removed and the mutable value will be updated with `v-model:page-stack="someMutableValue"`.
+
+For other use cases of `popPage`, you should now specify which type of user interaction to overwrite:
+
+- **Device back button**: Add ` @deviceBackButton.prevent="deviceBackButtonHandler" `.
+- **Swipe to pop**: Use `@postpop="postpopHandler"`. The event object contains a key `swipeToPop` which can be used to detect if the `postpop` was triggered by a user swiping to pop.
+- **Clicking a VOnsBackButton**: Add ` @click.prevent ` to the VOnsBackButton. Alternatively, if you just need to do some update after the page has popped, do the same as swipe to pop above, but use the `onsBackButton` event key instead of `swipeToPop`.
+
+##### Lazy repeat
+
+The vue-onsenui v3 version of VOnsLazyRepeat now requires that an object be returned by `renderItem` instead of a Vue instance. In most cases, this just means removing `new Vue` and returning the component object directly:
+
+```js
+export default {
+  data() {
+    return {
+      renderItem: i => ({  // The object is returned here. Before, this would have been `new Vue`.
+        template: `<v-ons-list-item :index="index" :key="index">#{{ index }}</v-ons-list-item>`,
+        data() {
+          return {
+            index: i
+          };
+        }
+      })
+    };
+  }
+};
+```
+
+##### Popover
+
+The value of VOnsPopover's `target` prop must now be a Vue ref.
+
+```js
+<v-ons-toolbar-button ref="myToolbarButton">Test</v-ons-toolbar-button>
+
+<v-ons-popover :target="$refs.myToolbarButton">
+  Popover
+</v-ons-popover>
+```
+
 <% end %>
 

--- a/src/documents_en/v2/guide/vue3/index.html
+++ b/src/documents_en/v2/guide/vue3/index.html
@@ -229,10 +229,7 @@ This way, changes take effect before any component is rendered.
 
 ##### How do I pass data to the next page in the navigator?
 
-_TODO_
-
-<!--
-A Navigator's pages are sibling elements, which means that communication among them in Vue is fairly challenging. [Vuex](https://vuex.vuejs.org/) is a good solution for this, but not the only one. When you push a new page component and want to add some initial data, you can simply extend it:
+A Navigator's pages are sibling elements, which means that communication among them in Vue is fairly challenging. [Pinia](https://pinia.vuejs.org/) is a good solution for this, but not the only one. When you push a new page component and want to add some initial data, you can simply extend it:
 
 ```
 import nextPage from 'nextPage.vue';
@@ -247,9 +244,6 @@ pageStack.push({
   }
 })
 ```
-
-In order to send data back to the previous page before popping, take a look at [Vue state management](https://vuejs.org/v2/guide/state-management.html).
--->
 
 ##### Can I use Pinia with Onsen UI?
 

--- a/src/misc/item-reference.html
+++ b/src/misc/item-reference.html
@@ -123,7 +123,7 @@ actionbar: false
           </span>
         </h4>
       </a>
-      <% if @framework != 'vue': %>
+      <% if @framework != 'vue' and @framework != 'vue3': %>
         <a class="edit-link" target="_blank" href="<%= @getEditLink(@original, @framework) %>">[<%= @translate '[en]improve this[/en][ja]編集[/ja]' %>]</a>
       <% end %>
     </div>
@@ -184,7 +184,7 @@ actionbar: false
               <span style="font-size: 12px"><% if @lang == "en": %>Optional.<% else: %>Optional.<% end %></span>
               <% end %>
 
-              <% if @framework == 'vue': %>
+              <% if @framework == 'vue' or @framework == 'vue3': %>
                 <a href="<%= @getEditLink(@original, @framework, attribute) %>" target="_blank">
                   <i class="fa fa-pencil edit-icon"></i>
                 </a>
@@ -284,7 +284,7 @@ actionbar: false
           </span>
         </h4>
       </a>
-      <% if @framework != 'vue': %>
+      <% if @framework != 'vue' and @framework != 'vue3': %>
         <a class="edit-link" target="_blank" href="<%= @getEditLink(@original, @framework) %>">[<%= @translate '[en]improve this[/en][ja]編集[/ja]' %>]</a>
       <% end %>
     </div>
@@ -346,7 +346,7 @@ actionbar: false
               <div class="deprecated-message"><%= @translate '[en]Deprecated.[/en][ja]非推奨[/ja]' %></div>
               <% end %>
 
-              <% if @framework == 'vue': %>
+              <% if @framework == 'vue' or @framework == 'vue3': %>
                 <a href="<%= @getEditLink(@original, @framework, prop) %>" target="_blank">
                   <i class="fa fa-pencil edit-icon"></i>
                 </a>
@@ -374,7 +374,7 @@ actionbar: false
           </span>
         </h4>
       </a>
-      <% if @framework != 'vue': %>
+      <% if @framework != 'vue' and @framework != 'vue3': %>
         <a class="edit-link" target="_blank" href="<%= @getEditLink(@original, @framework) %>">[<%= @translate '[en]improve this[/en][ja]編集[/ja]' %>]</a>
       <% end %>
     </div>
@@ -416,7 +416,7 @@ actionbar: false
             <% end %>
             <% end %>
 
-            <% if @framework == 'vue': %>
+            <% if @framework == 'vue' or @framework == 'vue3': %>
               <a href="<%= @getEditLink(@original, @framework, modifier) %>" target="_blank">
                 <i class="fa fa-pencil edit-icon"></i>
               </a>
@@ -441,7 +441,7 @@ actionbar: false
           </span>
         </h4>
       </a>
-      <% if @framework != 'vue': %>
+      <% if @framework != 'vue' and @framework != 'vue3': %>
         <a class="edit-link" target="_blank" href="<%= @getEditLink(@original, @framework) %>">[<%= @translate '[en]improve this[/en][ja]編集[/ja]' %>]</a>
       <% end %>
     </div>
@@ -484,7 +484,7 @@ actionbar: false
               <% end %>
               <% end %>
               <% if method.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
-              <% if @framework == 'vue': %>
+              <% if @framework == 'vue' or @framework == 'vue3': %>
                 <a href="<%= @getEditLink(@original, @framework, method) %>" target="_blank">
                   <i class="fa fa-pencil edit-icon"></i>
                 </a>
@@ -529,7 +529,7 @@ actionbar: false
         <!-- method parameter -->
         <h6><% if @lang == "en": %>Parameters<% else: %>パラメーター<% end %></h6>
 
-        <% if @framework == 'vue': %>
+        <% if @framework == 'vue' or @framework == 'vue3': %>
           <a href="<%= @getEditLink(@original, @framework, method) %>" target="_blank">
             <i class="fa fa-pencil edit-icon"></i>
           </a>
@@ -569,7 +569,7 @@ actionbar: false
                   <% end %>
                   <% end %>
 
-                  <% if @framework == 'vue': %>
+                  <% if @framework == 'vue' or @framework == 'vue3': %>
                     <a href="<%= @getEditLink(@original, @framework, param) %>" target="_blank">
                       <i class="fa fa-pencil edit-icon"></i>
                     </a>
@@ -599,7 +599,7 @@ actionbar: false
           </span>
         </h4>
       </a>
-      <% if @framework != 'vue': %>
+      <% if @framework != 'vue' and @framework != 'vue3': %>
         <a class="edit-link" target="_blank" href="<%= @getEditLink(@original, @framework) %>">[<%= @translate '[en]improve this[/en][ja]編集[/ja]' %>]</a>
       <% end %>
     </div>
@@ -645,7 +645,7 @@ actionbar: false
               <% end %>
               <% end %>
               <% if event.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
-              <% if @framework == 'vue': %>
+              <% if @framework == 'vue' or @framework == 'vue3': %>
                 <a href="<%= @getEditLink(@original, @framework, event) %>" target="_blank">
                   <i class="fa fa-pencil edit-icon"></i>
                 </a>
@@ -682,7 +682,7 @@ actionbar: false
 
         <% if event.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
 
-        <% if @framework == 'vue': %>
+        <% if @framework == 'vue' or @framework == 'vue3': %>
           <a href="<%= @getEditLink(@original, @framework, event) %>" target="_blank">
             <i class="fa fa-pencil edit-icon"></i>
           </a>
@@ -723,7 +723,7 @@ actionbar: false
                 <% end %>
                 <% end %>
 
-                <% if @framework == 'vue': %>
+                <% if @framework == 'vue' or @framework == 'vue3': %>
                   <a href="<%= @getEditLink(@original, @framework, param) %>" target="_blank">
                     <i class="fa fa-pencil edit-icon"></i>
                   </a>
@@ -781,7 +781,7 @@ actionbar: false
                   <% end %>
                   <% end %>
                   <% if input.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
-                  <% if @framework == 'vue': %>
+                  <% if @framework == 'vue' or @framework == 'vue3': %>
                     <a href="<%= @getEditLink(@original, @framework, input) %>" target="_blank">
                       <i class="fa fa-pencil edit-icon"></i>
                     </a>
@@ -832,7 +832,7 @@ actionbar: false
                   <% end %>
                   <% end %>
                   <% if output.deprecated: %><div class="deprecated-message"><%= @translate '[en]Deprecated[/en][ja]非推奨[/ja]' %></div><% end %>
-                  <% if @framework == 'vue': %>
+                  <% if @framework == 'vue' or @framework == 'vue3': %>
                     <a href="<%= @getEditLink(@original, @framework, output) %>" target="_blank">
                       <i class="fa fa-pencil edit-icon"></i>
                     </a>

--- a/src/partials/docs-nav.html.eco
+++ b/src/partials/docs-nav.html.eco
@@ -43,6 +43,12 @@
               Vue 2
             </a>
           </div>
+          <div class="docs-nav-dropdown-item <%- 'docs-nav-dropdown-item-active' if @framework == 'vue3' %>">
+            <a href="/v2/<%= @type %>/vue3/<%= @mapComponentName(@original, 'vue') + '.html' if @refdet and @original %>">
+              <img src="/images/common/icn_vue_4c.svg">
+              Vue 3
+            </a>
+          </div>
           <div class="docs-nav-dropdown-item <%- 'docs-nav-dropdown-item-active' if @framework == 'onsen1' %>">
             <a href="/v1/<%- if @reference then 'reference/javascript.html' else 'guide.html' %>">
               <img src="/images/common/icn_something_4c.svg">
@@ -54,6 +60,8 @@
         <div class="docs-nav-framework-icon">
           <% if @framework == 'onsen1' or typeof @framework != 'string': %>
             <img src="/images/common/icn_something_1c.svg">
+          <% else if @framework == 'vue3' or @framework == 'vue': %>
+            <img src="/images/common/icn_vue_1c.svg">
           <% else: %>
             <img src="/images/common/icn_<%=@framework%>_1c.svg">
           <% end %>
@@ -69,6 +77,8 @@
             JavaScript Core
           <% else if @framework == 'vue': %>
             Vue 2
+          <% else if @framework == 'vue3': %>
+            Vue 3
           <% else if @framework == 'onsen1' or typeof @framework != 'string': %>
             Onsen UI v1
           <% end %>

--- a/src/partials/footer.html.eco
+++ b/src/partials/footer.html.eco
@@ -47,7 +47,8 @@
             <a href="/v2/api/angular1" class="footer-container-navigation-link">AngularJS 1.x</a>
             <a href="/v2/api/angular2" class="footer-container-navigation-link">Angular 2+</a>
             <a href="/v2/api/react" class="footer-container-navigation-link">React</a>
-            <a href="/v2/api/vue" class="footer-container-navigation-link">Vue.js</a>
+            <a href="/v2/api/vue" class="footer-container-navigation-link">Vue.js 2</a>
+            <a href="/v2/api/vue3" class="footer-container-navigation-link">Vue.js 3</a>
             <a href="/v1/reference/javascript.html" class="footer-container-navigation-link">Onsen UI 1.x</a>
           </div>
           <div class="footer-container-navigation-column">

--- a/src/partials/global-nav.html.eco
+++ b/src/partials/global-nav.html.eco
@@ -70,7 +70,10 @@
               <a href="/v2/api/react">React</a>
             </li>
             <li class="dropdown-item-1">
-              <a href="/v2/api/vue">Vue.js</a>
+              <a href="/v2/api/vue">Vue.js 2</a>
+            </li>
+            <li class="dropdown-item-1">
+              <a href="/v2/api/vue3">Vue.js 3</a>
             </li>
             <li class="dropdown-item-1">
               <a href="/v1/reference/javascript.html">Onsen UI 1.x</a>

--- a/src/partials/global-nav.html.eco
+++ b/src/partials/global-nav.html.eco
@@ -38,7 +38,10 @@
               <a href="/v2/guide/react/">React</a>
             </li>
             <li class="dropdown-item-2">
-              <a href="/v2/guide/vue/">Vue.js</a>
+              <a href="/v2/guide/vue/">Vue.js 2</a>
+            </li>
+            <li class="dropdown-item-2">
+              <a href="/v2/guide/vue3/">Vue.js 3</a>
             </li>
             <li class="dropdown-item-1">
               <a href="/v1/guide.html">Onsen UI 1.x</a>


### PR DESCRIPTION
Adds API documentation and guide for Vue 3.

~Still need to add FAQ entry about using VOnsNavigator with extends. This will be done when we have a solution to OnsenUI/OnsenUI#2877.~ Done.

Fixes OnsenUI/OnsenUI#2998.